### PR TITLE
Fix viewing export batch when an attribute key is deleted

### DIFF
--- a/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/AttributeKey.php
+++ b/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/AttributeKey.php
@@ -31,7 +31,7 @@ class AttributeKey extends AbstractType
     {
         $ak = Key::getInstanceByID($exportItem->getItemIdentifier());
 
-        return array($ak->getAttributeKeyDisplayName());
+        return array($ak ? $ak->getAttributeKeyDisplayName() : h('<' . t('Deleted Attribute Key') . '>'));
     }
 
     public function getItemsFromRequest($array)


### PR DESCRIPTION
1. I created an export batch
2. I added to it an attribute key
3. I deleted the attribute key
4. I wanted to remove the attribute key from the export batch

Results when viewing the export batch:

```
Call to a member function getAttributeKeyDisplayName() on null
```

Let's avoid that.